### PR TITLE
Modify mkapp to work on os x

### DIFF
--- a/psycho-mkapp
+++ b/psycho-mkapp
@@ -28,7 +28,7 @@ project_skel() {
 	if [ "$file" != "$newname" ]; then
 	    mv "$file" "$newname"
 	fi
-	sed -i "s/app_id/$app_id/" "$newname"
+	sed -i -e "s/app_id/$app_id/" "$newname"
     done
 }
 


### PR DESCRIPTION
Without `-e` silly os x will complain about labels.

``` bash
+ '[' /Users/brettk/fun/psycho_app/erlang.mk '!=' /Users/brettk/fun/psycho_app/erlang.mk ']'
+ sed -i s/app_id/psycho_app/ /Users/brettk/fun/psycho_app/erlang.mk
sed: 1: "/Users/brettk/fun/psych ...": undefined label 'rettk/fun/psycho_app/erlang.mk'
```
